### PR TITLE
chore(ci): stabilize SOPS decrypt

### DIFF
--- a/.github/actions/sops-setup/action.yml
+++ b/.github/actions/sops-setup/action.yml
@@ -30,8 +30,6 @@ runs:
         command -v sops && sops --version
     - name: Decrypt repo vault to .env.local
       shell: bash
-      env:
-        SOPS_AGE_KEY_FILE: $HOME/.config/age/key.txt
       run: |
         if [ -f .secrets/dev.env.enc ]; then
           sops -d --input-type dotenv --output-type dotenv .secrets/dev.env.enc > .env.local


### PR DESCRIPTION
Install sops via binary, copy age key to ~/.config/sops/age/keys.txt, and remove SOPS_AGE_KEY_FILE override.